### PR TITLE
Introduce a failure condition for concerts.

### DIFF
--- a/music.md
+++ b/music.md
@@ -1,6 +1,6 @@
 # Music
 
-A *concert* is an event consisting of a series of songs, in which the band attempts to accrue points that represent their growing fame and renown, while not killing *too* many of the audience lest they anger the hosting town, village, or nation-state.
+A *concert* is an event consisting of a series of songs, in which the band attempts to accrue points that effect their growing [Fame](fame.md), while not killing *too* many of the audience lest they anger the hosting town, village, or nation-state.
 
 Concerts proceed with a sequence of turns that players take, going around the table in a simple loop. The band can choose whomever they wish to take the first turn.
 

--- a/music.md
+++ b/music.md
@@ -40,6 +40,10 @@ Finishing a song in a satisfying crescendo requires participation from the whole
 
 The player then introduces the next song, and the concert continues with the next player's turn.
 
+## Failure
+
+If a full round passes with no passed performance checks, the band is booed off the stage.
+
 ## Finishing a Concert
 
 Concerts are over when we get bored with them.


### PR DESCRIPTION
When I first wrote this up, @jlitzwilson pointed out that concerts have no failure state. She mentioned that she'd find it frustrating to be playing a concert where everything was going terribly, but it just kept dragging on with no consequences. Furthermore, @docwbritt introduced the Fame mechanic in #5, so it would be helpful to capture the idea that a concert could _diminish_ your Fame as well as enhance it, if you sucked that night.

I didn't like the "accumulating failed rolls" mechanic from 4E skill challenges for this, but we do need some way to capture "getting booed offstage."
